### PR TITLE
Fix API URL. Fixes #10

### DIFF
--- a/custom_components/pajgps/device_tracker.py
+++ b/custom_components/pajgps/device_tracker.py
@@ -344,6 +344,8 @@ async def get_devices(token):
     #   -H 'X-CSRF-TOKEN: '
     # Returns dictionary of device id, name, imei, model and has_battery from response.success.
 
+    _LOGGER.debug("Getting devices")
+
     url = API_URL + "device"
     payload = {}
     headers = {
@@ -389,6 +391,8 @@ async def get_device_data(token, device_id):
     #   -H 'Authorization: Bearer TOKEN' \
     #   -H 'X-CSRF-TOKEN: '
     # Returns instance of PAJGPSTrackerData object.
+
+    _LOGGER.debug("Getting device data")
 
     url = API_URL + f"trackerdata/{device_id}/last_points"
     payload = {}

--- a/custom_components/pajgps/device_tracker.py
+++ b/custom_components/pajgps/device_tracker.py
@@ -392,7 +392,7 @@ async def get_device_data(token, device_id):
     #   -H 'X-CSRF-TOKEN: '
     # Returns instance of PAJGPSTrackerData object.
 
-    _LOGGER.debug("Getting device data")
+    _LOGGER.debug(f"Getting data for device: {device_id}")
 
     url = API_URL + f"trackerdata/{device_id}/last_points"
     payload = {}

--- a/custom_components/pajgps/device_tracker.py
+++ b/custom_components/pajgps/device_tracker.py
@@ -15,7 +15,7 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=30)
-API_URL = "https://connect.paj-gps.de/api/"
+API_URL = "https://connect.paj-gps.de/api/v1/"
 VERSION = "0.3.0"
 
 TOKEN = None


### PR DESCRIPTION
* To fix #10 (Seems like the URL needs to be `https://connect.paj-gps.de/api/v1/`
* Added extra debug logging. Can be enabled in `configuration.yaml`
```yaml
logger:
  default: error 
  logs:
    custom_components.pajgps.device_tracker: debug
```

<img width="966" alt="image" src="https://github.com/user-attachments/assets/e404f82c-63ad-4d7b-bb7f-f9d42e6e115f">


