### PR TITLE
Fix availability check ignoring redirects, surface fix_time on the tracker

### DIFF
--- a/custom_components/pajgps/api/positions.py
+++ b/custom_components/pajgps/api/positions.py
@@ -56,6 +56,7 @@ async def fetch_positions(device_ids: list[int], headers: dict) -> tuple[list[Pa
             device["direction"],
             device["speed"],
             device["battery_level"],
+            fix_time=device.get("dateunix"),
         )
         for device in raw_json["success"]
     ]

--- a/custom_components/pajgps/device_tracker.py
+++ b/custom_components/pajgps/device_tracker.py
@@ -5,7 +5,7 @@ and updating their state based on the data received from the Paj GPS API.
 """
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.core import HomeAssistant
@@ -28,6 +28,7 @@ class PajGPSPositionSensor(TrackerEntity):
     _device_id = None
     _longitude: float | None = None
     _latitude: float | None = None
+    _fix_time: int | None = None
 
     def __init__(self, pajgps_data: PajGPSData, device_id: int) -> None:
         """Initialize the sensor."""
@@ -71,11 +72,25 @@ class PajGPSPositionSensor(TrackerEntity):
         """Return the source type, eg gps or router, of the device."""
         return "gps"
 
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return the device's own fix time, so a consumer can tell a fresh
+        position from a stale one replaying the last known coordinates --
+        neither is otherwise distinguishable anywhere in Home Assistant."""
+        if self._fix_time is None:
+            return None
+        return {
+            "fix_time": datetime.fromtimestamp(
+                self._fix_time, tz=timezone.utc
+            ).isoformat()
+        }
+
     async def async_update(self) -> None:
         """Update the GPS sensor data."""
         await self._pajgps_data.update_pajgps_data()
         position_data = self._pajgps_data.get_position(self._device_id)
         if position_data is not None:
+            self._fix_time = position_data.fix_time
             if position_data.lat is not None and position_data.lng is not None:
                 self._latitude = position_data.lat
                 self._longitude = position_data.lng
@@ -83,6 +98,7 @@ class PajGPSPositionSensor(TrackerEntity):
                 self._latitude = None
                 self._longitude = None
         else:
+            self._fix_time = None
             self._latitude = None
             self._longitude = None
 

--- a/custom_components/pajgps/models.py
+++ b/custom_components/pajgps/models.py
@@ -87,8 +87,18 @@ class PajGPSPositionData:
     speed: int
     battery_level: int
     last_elevation_update: float = 0.0
+    fix_time: int | None = None
 
-    def __init__(self, device_id: int, lat: float, lng: float, direction: int, speed: int, battery_level: int) -> None:
+    def __init__(
+        self,
+        device_id: int,
+        lat: float,
+        lng: float,
+        direction: int,
+        speed: int,
+        battery_level: int,
+        fix_time: int | None = None,
+    ) -> None:
         """Initialize the PajGPSPositionData class."""
         self.device_id = device_id
         self.lat = lat
@@ -96,6 +106,12 @@ class PajGPSPositionData:
         self.direction = direction
         self.speed = speed
         self.battery_level = battery_level
+        # Unix timestamp (seconds) of when the device actually reported this
+        # position -- the "dateunix" field on each element of
+        # getalllastpositions' success[]. Optional because it's new; older
+        # callers/tests that don't pass it still get a working object, they
+        # just don't get staleness info.
+        self.fix_time = fix_time
 
 
 class PajGPSSensorData:

--- a/custom_components/pajgps/requests.py
+++ b/custom_components/pajgps/requests.py
@@ -36,7 +36,13 @@ async def check_pajgps_availability(timeout: int = 15) -> bool:
         session = aiohttp.ClientSession(timeout=timeout_config)
 
         try:
-            async with session.head(API_BASE_URL) as response:
+            # allow_redirects=True: the root domain 302s to /login by design
+            # (this is normal PAJ behaviour, not an outage). aiohttp's HEAD
+            # requests don't follow redirects by default (unlike GET), so
+            # without this the check always saw the bare 302 and reported
+            # "not reachable" even when the API was fine -- which then
+            # skipped every real data update behind it.
+            async with session.head(API_BASE_URL, allow_redirects=True) as response:
                 if response.status != 200:
                     _LOGGER.warning("API URL is not reachable (status %s)", response.status)
                     return False


### PR DESCRIPTION
## Summary

Found while diagnosing why a tracker with a dead battery kept showing as "home" in Home Assistant indefinitely, instead of ever going unavailable. Two separate bugs, both fixed here.

**1. `check_pajgps_availability()` ignores redirects on the availability probe.** It does a bare `session.head(API_BASE_URL)`. `aiohttp` does not follow redirects on HEAD requests by default (unlike GET, which does). The root domain 302s to `/login` by design — normal behaviour, not an outage — but this check always saw the bare 302 and logged "API URL is not reachable", which then skipped every real data update behind it. Fixed with `allow_redirects=True`.

**2. `dateunix` (the only timestamp on a position record) is fetched but never used.** `getalllastpositions` returns a `dateunix` field on every device in `success[]`, but `fetch_positions()` never reads it, so it never reaches `PajGPSPositionData`, the coordinator, or any entity. A device that's stopped transmitting (dead battery, no sky view, whatever) keeps replaying its last cached lat/lng at every 30-second poll forever, with nothing anywhere in Home Assistant to distinguish that from a live fix.

Threaded `dateunix` through as `fix_time` (`models.py`, following the same optional-field pattern already used for `elevation`/`last_elevation_update`) and surfaced it as an `extra_state_attribute` on the tracker (ISO 8601 UTC), so automations and the frontend can finally tell a fresh fix from a stale one.

Repro for (2), against a real account with a device whose battery died months ago:

```
curl -s -X POST 'https://connect.paj-gps.de/api/v1/trackerdata/getalllastpositions' \
  -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' \
  -d '{"deviceIDs":[<id>],"fromLastPoint":false}'
```

returned `dateunix` from months prior, while Home Assistant showed the tracker "home" with `last_updated` refreshing every 30 seconds the whole time.

Backwards compatible — `fix_time` is an optional trailing keyword argument. Existing code constructing `PajGPSPositionData` with the original six positional args is unaffected.

**Separately, not included here to keep this focused:** `sensordata/last` appears to return `{"success": []}` for a device that's stopped transmitting, and the integration currently treats that as "no change" rather than surfacing it — likely why alert-backed binary sensors for a dead device sit at "off" forever instead of going unavailable. Happy to open that as its own issue/PR if useful.

## Test plan
- [x] Verified the timestamp math against the real known value (`dateunix=1782719612` → `2026-06-29T07:53:32+00:00`, matching the device's actual last-transmission time)
- [x] Verified `PajGPSPositionData`'s old 6-positional-arg construction still works unchanged (backwards compatible)
- [x] Verified the `fetch_positions()` list-comprehension shape against a mocked real API response, including a device missing `dateunix` entirely (defensive `.get()`, doesn't crash)
- [ ] Not run against the full `homeassistant` test harness (`tests/test_pajgps_data.py` needs live `PAJGPS_EMAIL`/`PAJGPS_PASSWORD` env vars and hits the real API) — happy to if that's expected before merge
